### PR TITLE
Add more eye-friendly colors for linkrefs and headers in markdown (#23)

### DIFF
--- a/colors/palenight.vim
+++ b/colors/palenight.vim
@@ -314,6 +314,8 @@ call s:h("jsonSemicolonError", { "fg": s:red, "gui": "reverse" })
 
 " Markdown
 call s:h("markdownCode", { "fg": s:green })
+call s:h("markdownLinkReference", { "fg": s:comment_grey })
+call s:h("markdownJekyllFrontMatter", { "fg": s:comment_grey })
 call s:h("markdownCodeBlock", { "fg": s:green })
 call s:h("markdownCodeDelimiter", { "fg": s:green })
 call s:h("markdownHeadingDelimiter", { "fg": s:red })


### PR DESCRIPTION
Patch relevant when using https://github.com/gabrielelana/vim-markdown